### PR TITLE
Add Openwork to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,12 @@ format:
     - 2024
     - [code](https://github.com/browser-use/browser-use)
 
+- [Openwork: Open-source Browser Automation Agent](https://github.com/accomplish-ai/openwork)
+    - Accomplish AI
+    - Key: browser automation, computer-use agents, multi-LLM support, open-source
+    - 2025
+    - [code](https://github.com/accomplish-ai/openwork)
+
 - [ToolGen: Unified Tool Retrieval and Calling via Generation](https://openreview.net/forum?id=XLMAMmowdY)  
   - Renxi Wang, Xudong Han, Lei Ji, Shu Wang, Timothy Baldwin, Haonan Li  
   - Key: Agent, Tool Learning, Virtual Token  


### PR DESCRIPTION
## Summary
- Adds [Openwork](https://github.com/accomplish-ai/openwork) to the Tools section

## About Openwork
Openwork is an MIT-licensed, open alternative to Anthropic's Cowork, built using [Opencode](https://github.com/anomalyco/opencode) and [dev-browser](https://github.com/SawyerHood/dev-browser). It supports multiple LLM providers and lets users launch computer-use agents to automate real browser workflows—faster, safer, and fully open source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)