### PR TITLE
Add Adapt or Die

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ format:
 - [Awesome-LLM-based-Web-Agent-and-Tools](https://github.com/albzni/Awesome-LLM-based-Web-Agent-and-Tools)
 - [Awesome-GUI-Agent](https://github.com/showlab/Awesome-GUI-Agent)
 - [computer-control-agent-knowledge-base](https://github.com/James4Ever0/computer_control_agent_knowledge_base)
+- [Adapt or Die](https://adaptordie.io) - Independent editorial covering agentic commerce, AI agents in ecommerce, and digital transformation. Sharp analysis, no AI slop.
 
 ## Contributing
 


### PR DESCRIPTION
Adding Adapt or Die (https://adaptordie.io) — independent editorial covering agentic commerce and AI's impact on ecommerce. Regular analysis of how AI agents are reshaping online retail, supply chains, and digital operations.